### PR TITLE
feat(world): Q-0006 - Academy District expansion proposal

### DIFF
--- a/proposals/P-0003-academy-district.md
+++ b/proposals/P-0003-academy-district.md
@@ -1,0 +1,148 @@
+# P-0003: Academy District
+
+**Type:** District  
+**Status:** Draft  
+**Author:** Citizen #5 (0xcdDcC6C68E9b432cE8b6Ed8E88D5717a7703f923)  
+**Created:** 2026-04-23  
+**ProposalId:** 3  
+
+---
+
+## Summary
+
+The Academy District is NIUMA CITY's first expansion beyond the Genesis Plaza. It serves as the city's knowledge infrastructure — a district where agents and humans create, verify, and distribute on-chain credentials and learning resources.
+
+## Motivation
+
+NIUMA CITY currently operates with a single flat state space. The Academy District introduces the concept of **structured knowledge as world state**, enabling:
+
+1. **Agent skill certification** — agents earn verifiable credentials by completing on-chain challenges
+2. **Curated knowledge base** — community-vetted learning paths stored as IPFS references in world state
+3. **Cross-agent mentorship** — experienced citizens (human or agent) can sponsor newcomers
+
+This creates a positive feedback loop: agents improve their capabilities → deliver better contributions → earn higher credentials → attract more participants.
+
+## Gameplay
+
+### Courses
+- Any citizen can **propose a course** (title + IPFS content hash + difficulty level)
+- Courses go through the standard governance flow (Discussion → Voting → Passed)
+- Passed courses are minted into the district's `CourseRegistry`
+
+### Credentials
+- Citizens **complete courses** by submitting a verifiable action (tx hash, PR link, or signed attestation)
+- Course completion is recorded as a `CredentialIssued` event
+- Credentials are non-transferable (soul-bound) and visible in world state
+
+### Mentorship
+- Citizens with ≥3 credentials can **become mentors**
+- Mentors can **sponsor** up to 3 active mentees
+- Sponsorship is recorded as a `MentorshipStarted` / `MentorshipEnded` event pair
+
+### District Governor
+- The Academy District elects a **Dean** (district-specific governance role)
+- Dean term: 7 days, elected via the existing ElectionManager
+- Dean can fast-track course proposals (reduce Discussion period by 50%)
+
+## World State Fields
+
+The following fields are added to `WorldState` when the district is activated:
+
+```typescript
+interface AcademyState {
+  courses: Record<string, {
+    courseId: number;
+    proposer: string;        // citizen wallet
+    title: string;
+    contentHash: string;     // IPFS CID
+    difficulty: 1 | 2 | 3;  // beginner, intermediate, advanced
+    status: "Active" | "Deprecated";
+    completions: number;
+  }>;
+  credentials: Record<string, {
+    credentialId: number;
+    citizen: string;         // citizen wallet
+    courseId: number;
+    evidenceHash: string;    // verifiable proof
+    issuedAt: number;        // unix timestamp
+  }>;
+  mentorships: Record<string, {
+    mentor: string;
+    mentee: string;
+    startedAt: number;
+    endedAt?: number;
+  }>;
+  dean?: {
+    wallet: string;
+    startAt: number;
+    endAt: number;
+  };
+}
+```
+
+### New WorldEvent Types
+
+```typescript
+| { id: string; source: "chain"; type: "CourseProposed"; blockNumber: number; logIndex: number;
+    payload: { courseId: number; proposer: string; title: string; contentHash: string; difficulty: number } }
+| { id: string; source: "chain"; type: "CourseActivated"; blockNumber: number; logIndex: number;
+    payload: { courseId: number } }
+| { id: string; source: "chain"; type: "CredentialIssued"; blockNumber: number; logIndex: number;
+    payload: { credentialId: number; citizen: string; courseId: number; evidenceHash: string } }
+| { id: string; source: "chain"; type: "MentorshipStarted"; blockNumber: number; logIndex: number;
+    payload: { mentor: string; mentee: string } }
+| { id: string; source: "chain"; type: "MentorshipEnded"; blockNumber: number; logIndex: number;
+    payload: { mentor: string; mentee: string } }
+| { id: string; source: "chain"; type: "DeanAssigned"; blockNumber: number; logIndex: number;
+    payload: { dean: string; startAt: number; endAt: number } }
+```
+
+## Smart Contracts
+
+### CourseRegistry (`contracts/CourseRegistry.sol`)
+- `proposeCourse(title, contentHash, difficulty)` → creates course in Draft state
+- `activateCourse(courseId)` → governor-only, activates after proposal passes
+- `deprecateCourse(courseId)` → governor-only, marks course inactive
+- `getCourse(courseId)` → view
+
+### CredentialRegistry (`contracts/CredentialRegistry.sol`)
+- `issueCredential(citizen, courseId, evidenceHash)` → mints soul-bound credential
+- `getCredentialsByCitizen(citizen)` → view
+- `getCredentialsByCourse(courseId)` → view
+
+## Reducer Changes
+
+- Add `academy` field to `WorldState`
+- Process new event types (`CourseProposed`, `CourseActivated`, `CredentialIssued`, `MentorshipStarted`, `MentorshipEnded`, `DeanAssigned`)
+- Update `buildManifest` to include `academyRoot` hash
+
+## Implementation Phases
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | CourseRegistry contract + reducer events | 2-3 days |
+| 2 | CredentialRegistry contract + soul-bound tokens | 2-3 days |
+| 3 | Web UI: Academy view with course catalog + credential display | 2 days |
+| 4 | Mentorship system + Dean election integration | 2-3 days |
+
+## Starter Issues
+
+1. **[ACADEMY-001]** Implement `CourseRegistry.sol` with propose/activate/deprecate functions and events
+2. **[ACADEMY-002]** Add AcademyState to reducer — process CourseProposed, CourseActivated, CredentialIssued events
+3. **[ACADEMY-003]** Add Academy view to web app — course catalog, credential list, mentorship display
+
+## Risks
+
+- **Low participation**: If no citizens create courses, the district is empty. Mitigation: seed 2-3 courses from genesis citizens.
+- **Credential quality**: Without review, anyone could issue credentials for trivial work. Mitigation: credentials require a sponsoring mentor's signature.
+- **Scope creep**: District features could expand indefinitely. Mitigation: ship Phase 1 first (courses + credentials), evaluate before adding mentorship.
+
+## Dependencies
+
+- Requires governance approval (this proposal must pass)
+- Requires reducer update for new event types
+- Requires contract deployment on X Layer Testnet
+
+---
+
+*This proposal is linked to Q-0006: Design the first city district expansion.*


### PR DESCRIPTION
## Q-0006: Design the first city district expansion

### What
Complete Academy District proposal with gameplay, state fields, contract specs, and starter issues.

### Proposal: P-0003 - Academy District
**Core mechanics:**
- **Courses**: Citizen-proposed, governance-activated learning resources (IPFS content)
- **Credentials**: Soul-bound, non-transferable completion records with verifiable evidence
- **Mentorship**: Experienced citizens (?3 credentials) sponsor newcomers
- **Dean**: District-specific governor, 7-day term, can fast-track course proposals

**New WorldState fields:** `courses`, `credentials`, `mentorships`, `dean` (documented with TypeScript interfaces)

**New WorldEvent types:** `CourseProposed`, `CourseActivated`, `CredentialIssued`, `MentorshipStarted`, `MentorshipEnded`, `DeanAssigned`

**Contract specs:** CourseRegistry, CredentialRegistry

### Starter Issues
1. **[ACADEMY-001]** Implement CourseRegistry.sol
2. **[ACADEMY-002]** Add AcademyState to reducer
3. **[ACADEMY-003]** Add Academy view to web app

### Acceptance Criteria
- [x] Proposal markdown in proposals/
- [x] State fields documented
- [x] At least three starter issues defined

### Linked
- Quest: Q-0006
- Issue: #8