### PR TITLE
feat(contracts): Academy District Phase 1 - CourseRegistry + CredentialRegistry

### DIFF
--- a/apps/node/src/chain.ts
+++ b/apps/node/src/chain.ts
@@ -29,6 +29,17 @@ const companyAbi = [
 
 const roleAbi = ["event MayorAssigned(address indexed mayor,uint256 startAt,uint256 endAt)"];
 
+const courseAbi = [
+  "event CourseProposed(uint256 indexed courseId,address indexed proposer,string title,string contentHash,uint8 difficulty)",
+  "event CourseActivated(uint256 indexed courseId)",
+  "event CourseDeprecated(uint256 indexed courseId)",
+  "event CourseCompleted(uint256 indexed courseId,address indexed citizen)"
+];
+
+const credentialAbi = [
+  "event CredentialIssued(uint256 indexed credentialId,address indexed citizen,uint256 indexed courseId,string evidenceHash)"
+];
+
 const proposalTypes = ["Feature", "Governance", "District", "Company"];
 const proposalStatuses = ["Draft", "Discussion", "Voting", "Passed", "Rejected", "Executed"];
 
@@ -75,7 +86,9 @@ async function syncChainEventsOnce() {
       { name: "CitizenRegistry", address: deployment.contracts.CitizenRegistry, abi: citizenAbi, mapper: mapCitizenEvent },
       { name: "GovernanceCore", address: deployment.contracts.GovernanceCore, abi: governanceAbi, mapper: mapGovernanceEvent },
       { name: "CompanyRegistry", address: deployment.contracts.CompanyRegistry, abi: companyAbi, mapper: mapCompanyEvent },
-      { name: "RoleManager", address: deployment.contracts.RoleManager, abi: roleAbi, mapper: mapRoleEvent }
+      { name: "RoleManager", address: deployment.contracts.RoleManager, abi: roleAbi, mapper: mapRoleEvent },
+      { name: "CourseRegistry", address: deployment.contracts.CourseRegistry, abi: courseAbi, mapper: mapCourseEvent },
+      { name: "CredentialRegistry", address: deployment.contracts.CredentialRegistry, abi: credentialAbi, mapper: mapCredentialEvent }
     ];
 
     let added = 0;
@@ -283,6 +296,74 @@ function mapRoleEvent(log: any): WorldEvent | undefined {
   };
 }
 
+function mapCourseEvent(log: any): WorldEvent | undefined {
+  const event = log.fragment?.name;
+  if (event === "CourseProposed") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "CourseProposed",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: {
+        courseId: Number(log.args.courseId),
+        proposer: log.args.proposer,
+        title: log.args.title,
+        contentHash: log.args.contentHash,
+        difficulty: Number(log.args.difficulty)
+      }
+    };
+  }
+  if (event === "CourseActivated") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "CourseActivated",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: { courseId: Number(log.args.courseId) }
+    };
+  }
+  if (event === "CourseDeprecated") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "CourseDeprecated",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: { courseId: Number(log.args.courseId) }
+    };
+  }
+  if (event === "CourseCompleted") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "CourseCompleted",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: { courseId: Number(log.args.courseId), citizen: log.args.citizen }
+    };
+  }
+  return undefined;
+}
+
+function mapCredentialEvent(log: any): WorldEvent | undefined {
+  if (log.fragment?.name !== "CredentialIssued") return undefined;
+  return {
+    id: chainEventId(log),
+    source: "chain",
+    type: "CredentialIssued",
+    blockNumber: log.blockNumber,
+    logIndex: log.index,
+    payload: {
+      credentialId: Number(log.args.credentialId),
+      citizen: log.args.citizen,
+      courseId: Number(log.args.courseId),
+      evidenceHash: log.args.evidenceHash
+    }
+  };
+}
+
 function chainEventId(log: any) {
   return `chain-${log.blockNumber}-${log.transactionIndex}-${log.index}-${log.transactionHash}`;
 }
@@ -295,7 +376,9 @@ function loadDeployment(): Deployment | null {
           CitizenRegistry: process.env.CITIZEN_REGISTRY,
           GovernanceCore: process.env.GOVERNANCE_CORE || "",
           RoleManager: process.env.ROLE_MANAGER || "",
-          CompanyRegistry: process.env.COMPANY_REGISTRY || ""
+          CompanyRegistry: process.env.COMPANY_REGISTRY || "",
+          CourseRegistry: process.env.COURSE_REGISTRY || "",
+          CredentialRegistry: process.env.CREDENTIAL_REGISTRY || ""
         }
       }
     : null;

--- a/apps/node/src/store.ts
+++ b/apps/node/src/store.ts
@@ -42,6 +42,22 @@ const seedEvents: WorldEvent[] = [
     blockNumber: 5,
     logIndex: 0,
     payload: { mayor: "0x0000000000000000000000000000000000000001", startAt: now - 1200, endAt: now + 86400 }
+  },
+  {
+    id: "seed-course-1",
+    source: "chain",
+    type: "CourseProposed",
+    blockNumber: 6,
+    logIndex: 0,
+    payload: { courseId: 1, proposer: "0x0000000000000000000000000000000000000001", title: "NIUMA City 101", contentHash: "ipfs://niuma-101", difficulty: 0 }
+  },
+  {
+    id: "seed-course-1-activated",
+    source: "chain",
+    type: "CourseActivated",
+    blockNumber: 7,
+    logIndex: 0,
+    payload: { courseId: 1 }
   }
 ];
 

--- a/contracts/contracts/CourseRegistry.sol
+++ b/contracts/contracts/CourseRegistry.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ICitizenRegistryForCourse {
+    function isCitizen(address owner) external view returns (bool);
+}
+
+contract CourseRegistry {
+    enum Difficulty { Beginner, Intermediate, Advanced }
+    enum CourseStatus { Draft, Active, Deprecated }
+
+    struct Course {
+        uint256 id;
+        address proposer;
+        string title;
+        string contentHash;
+        Difficulty difficulty;
+        CourseStatus status;
+        uint256 createdAt;
+        uint256 activatedAt;
+        uint256 completionCount;
+    }
+
+    ICitizenRegistryForCourse public immutable citizenRegistry;
+    uint256 public nextCourseId = 1;
+    mapping(uint256 => Course) private courses;
+
+    address public governor;
+
+    event CourseProposed(uint256 indexed courseId, address indexed proposer, string title, string contentHash, Difficulty difficulty);
+    event CourseActivated(uint256 indexed courseId);
+    event CourseDeprecated(uint256 indexed courseId);
+    event CourseCompleted(uint256 indexed courseId, address indexed citizen);
+
+    error OnlyCitizen();
+    error OnlyGovernor();
+    error CourseMissing();
+    error CourseNotDraft();
+    error CourseNotActive();
+    error CourseAlreadyActive();
+
+    constructor(address citizenRegistry_, address governor_) {
+        citizenRegistry = ICitizenRegistryForCourse(citizenRegistry_);
+        governor = governor_;
+    }
+
+    function proposeCourse(
+        string calldata title,
+        string calldata contentHash,
+        Difficulty difficulty
+    ) external onlyCitizen returns (uint256 courseId) {
+        courseId = nextCourseId++;
+        courses[courseId] = Course({
+            id: courseId,
+            proposer: msg.sender,
+            title: title,
+            contentHash: contentHash,
+            difficulty: difficulty,
+            status: CourseStatus.Draft,
+            createdAt: block.timestamp,
+            activatedAt: 0,
+            completionCount: 0
+        });
+        emit CourseProposed(courseId, msg.sender, title, contentHash, difficulty);
+    }
+
+    function activateCourse(uint256 courseId) external onlyGovernor {
+        Course storage course = existingCourse(courseId);
+        if (course.status != CourseStatus.Draft) revert CourseNotDraft();
+        course.status = CourseStatus.Active;
+        course.activatedAt = block.timestamp;
+        emit CourseActivated(courseId);
+    }
+
+    function deprecateCourse(uint256 courseId) external onlyGovernor {
+        Course storage course = existingCourse(courseId);
+        if (course.status != CourseStatus.Active) revert CourseNotActive();
+        course.status = CourseStatus.Deprecated;
+        emit CourseDeprecated(courseId);
+    }
+
+    function recordCompletion(uint256 courseId) external onlyCitizen {
+        Course storage course = existingCourse(courseId);
+        if (course.status != CourseStatus.Active) revert CourseNotActive();
+        course.completionCount += 1;
+        emit CourseCompleted(courseId, msg.sender);
+    }
+
+    function getCourse(uint256 courseId) external view returns (Course memory) {
+        return existingCourse(courseId);
+    }
+
+    function getCourseStatus(uint256 courseId) external view returns (uint8) {
+        Course storage course = existingCourse(courseId);
+        return uint8(course.status);
+    }
+
+    function getCourseCount() external view returns (uint256) {
+        return nextCourseId - 1;
+    }
+
+    function setGovernor(address newGovernor) external onlyGovernor {
+        governor = newGovernor;
+    }
+
+    function existingCourse(uint256 courseId) private view returns (Course storage course) {
+        course = courses[courseId];
+        if (course.id == 0) revert CourseMissing();
+    }
+
+    modifier onlyCitizen() {
+        if (!citizenRegistry.isCitizen(msg.sender)) revert OnlyCitizen();
+        _;
+    }
+
+    modifier onlyGovernor() {
+        if (msg.sender != governor) revert OnlyGovernor();
+        _;
+    }
+}

--- a/contracts/contracts/CredentialRegistry.sol
+++ b/contracts/contracts/CredentialRegistry.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ICitizenRegistryForCredential {
+    function isCitizen(address owner) external view returns (bool);
+}
+
+interface ICourseRegistryForCredential {
+    function getCourseStatus(uint256 courseId) external view returns (uint8);
+}
+
+contract CredentialRegistry {
+    struct Credential {
+        uint256 id;
+        address citizen;
+        uint256 courseId;
+        string evidenceHash;
+        uint256 issuedAt;
+        address issuedBy;
+    }
+
+    ICitizenRegistryForCredential public immutable citizenRegistry;
+    ICourseRegistryForCredential public immutable courseRegistry;
+    address public governor;
+
+    uint256 public nextCredentialId = 1;
+    mapping(uint256 => Credential) private credentials;
+    mapping(address => uint256[]) private credentialsByCitizen;
+    mapping(uint256 => uint256[]) private credentialsByCourse;
+    // One credential per course per citizen (prevent duplicate)
+    mapping(address => mapping(uint256 => bool)) public hasCredentialForCourse;
+
+    event CredentialIssued(uint256 indexed credentialId, address indexed citizen, uint256 indexed courseId, string evidenceHash);
+
+    error OnlyCitizen();
+    error OnlyGovernor();
+    error CourseNotActive();
+    error AlreadyHasCredential();
+    error CredentialMissing();
+
+    constructor(address citizenRegistry_, address courseRegistry_, address governor_) {
+        citizenRegistry = ICitizenRegistryForCredential(citizenRegistry_);
+        courseRegistry = ICourseRegistryForCredential(courseRegistry_);
+        governor = governor_;
+    }
+
+    function issueCredential(
+        address citizen,
+        uint256 courseId,
+        string calldata evidenceHash
+    ) external onlyGovernor returns (uint256 credentialId) {
+        if (!citizenRegistry.isCitizen(citizen)) revert OnlyCitizen();
+        // CourseStatus.Active = 1
+        if (courseRegistry.getCourseStatus(courseId) != 1) revert CourseNotActive();
+        if (hasCredentialForCourse[citizen][courseId]) revert AlreadyHasCredential();
+
+        credentialId = nextCredentialId++;
+        credentials[credentialId] = Credential({
+            id: credentialId,
+            citizen: citizen,
+            courseId: courseId,
+            evidenceHash: evidenceHash,
+            issuedAt: block.timestamp,
+            issuedBy: msg.sender
+        });
+        credentialsByCitizen[citizen].push(credentialId);
+        credentialsByCourse[courseId].push(credentialId);
+        hasCredentialForCourse[citizen][courseId] = true;
+
+        emit CredentialIssued(credentialId, citizen, courseId, evidenceHash);
+    }
+
+    function getCredential(uint256 credentialId) external view returns (Credential memory) {
+        if (credentials[credentialId].citizen == address(0)) revert CredentialMissing();
+        return credentials[credentialId];
+    }
+
+    function getCredentialsByCitizen(address citizen) external view returns (uint256[] memory) {
+        return credentialsByCitizen[citizen];
+    }
+
+    function getCredentialsByCourse(uint256 courseId) external view returns (uint256[] memory) {
+        return credentialsByCourse[courseId];
+    }
+
+    function getCredentialCount() external view returns (uint256) {
+        return nextCredentialId - 1;
+    }
+
+    function setGovernor(address newGovernor) external onlyGovernor {
+        governor = newGovernor;
+    }
+
+    modifier onlyGovernor() {
+        if (msg.sender != governor) revert OnlyGovernor();
+        _;
+    }
+}

--- a/contracts/test/NiumaCity.test.ts
+++ b/contracts/test/NiumaCity.test.ts
@@ -17,7 +17,11 @@ describe("Niuma City Alpha Protocol", function () {
     const ElectionManager = await ethers.getContractFactory("ElectionManager");
     const electionManager = await ElectionManager.deploy(await citizenRegistry.getAddress(), await roleManager.getAddress());
     await roleManager.setElectionController(await electionManager.getAddress());
-    return { owner, alice, bob, citizenRegistry, governanceCore, roleManager, companyRegistry, worldStateRegistry, electionManager };
+    const CourseRegistry = await ethers.getContractFactory("CourseRegistry");
+    const courseRegistry = await CourseRegistry.deploy(await citizenRegistry.getAddress(), owner.address);
+    const CredentialRegistry = await ethers.getContractFactory("CredentialRegistry");
+    const credentialRegistry = await CredentialRegistry.deploy(await citizenRegistry.getAddress(), await courseRegistry.getAddress(), owner.address);
+    return { owner, alice, bob, citizenRegistry, governanceCore, roleManager, companyRegistry, worldStateRegistry, electionManager, courseRegistry, credentialRegistry };
   }
 
   it("registers citizens as non-transferable identities", async function () {
@@ -81,5 +85,75 @@ describe("Niuma City Alpha Protocol", function () {
       companyRegistry,
       "AlreadyInCompany"
     );
+  });
+
+  it("proposes, activates, and deprecates courses in the Academy District", async function () {
+    const { owner, alice, bob, citizenRegistry, courseRegistry } = await deploy();
+    await citizenRegistry.connect(alice).registerCitizen(alice.address, "ipfs://alice");
+    await citizenRegistry.connect(bob).registerCitizen(bob.address, "ipfs://bob");
+
+    // Alice proposes a course
+    await expect(courseRegistry.connect(alice).proposeCourse("Solidity 101", "ipfs://solidity-101", 0))
+      .to.emit(courseRegistry, "CourseProposed")
+      .withArgs(1, alice.address, "Solidity 101", "ipfs://solidity-101", 0);
+
+    const course = await courseRegistry.getCourse(1);
+    expect(course.proposer).to.equal(alice.address);
+    expect(course.status).to.equal(0); // Draft
+    expect(course.difficulty).to.equal(0); // Beginner
+
+    // Only governor can activate
+    await expect(courseRegistry.connect(bob).activateCourse(1)).to.be.revertedWithCustomError(courseRegistry, "OnlyGovernor");
+
+    // Governor activates
+    await expect(courseRegistry.connect(owner).activateCourse(1)).to.emit(courseRegistry, "CourseActivated");
+    const activeCourse = await courseRegistry.getCourse(1);
+    expect(activeCourse.status).to.equal(1); // Active
+    expect(activeCourse.activatedAt).to.be.gt(0);
+
+    // Record completion
+    await courseRegistry.connect(bob).recordCompletion(1);
+    const completed = await courseRegistry.getCourse(1);
+    expect(completed.completionCount).to.equal(1);
+
+    // Governor deprecates
+    await expect(courseRegistry.connect(owner).deprecateCourse(1)).to.emit(courseRegistry, "CourseDeprecated");
+    const deprecated = await courseRegistry.getCourse(1);
+    expect(deprecated.status).to.equal(2); // Deprecated
+  });
+
+  it("issues soul-bound credentials for completed courses", async function () {
+    const { owner, alice, citizenRegistry, courseRegistry, credentialRegistry } = await deploy();
+    await citizenRegistry.connect(alice).registerCitizen(alice.address, "ipfs://alice");
+    await courseRegistry.connect(alice).proposeCourse("Agent Ops", "ipfs://agent-ops", 1);
+    await courseRegistry.connect(owner).activateCourse(1);
+
+    // Only governor can issue credentials
+    await expect(credentialRegistry.connect(alice).issueCredential(alice.address, 1, "sha256:evidence"))
+      .to.be.revertedWithCustomError(credentialRegistry, "OnlyGovernor");
+
+    // Governor issues credential
+    await expect(credentialRegistry.connect(owner).issueCredential(alice.address, 1, "sha256:evidence"))
+      .to.emit(credentialRegistry, "CredentialIssued")
+      .withArgs(1, alice.address, 1, "sha256:evidence");
+
+    const cred = await credentialRegistry.getCredential(1);
+    expect(cred.citizen).to.equal(alice.address);
+    expect(cred.courseId).to.equal(1);
+    expect(cred.evidenceHash).to.equal("sha256:evidence");
+
+    // Can't issue duplicate credential for same course
+    await expect(credentialRegistry.connect(owner).issueCredential(alice.address, 1, "sha256:evidence2"))
+      .to.be.revertedWithCustomError(credentialRegistry, "AlreadyHasCredential");
+
+    // Can't issue for non-active course
+    await courseRegistry.connect(alice).proposeCourse("Draft Course", "ipfs://draft", 2);
+    await expect(credentialRegistry.connect(owner).issueCredential(alice.address, 2, "sha256:evidence"))
+      .to.be.revertedWithCustomError(credentialRegistry, "CourseNotActive");
+
+    // Check credential lookups
+    const citizenCreds = await credentialRegistry.getCredentialsByCitizen(alice.address);
+    expect(citizenCreds.length).to.equal(1);
+    expect(citizenCreds[0]).to.equal(1);
   });
 });

--- a/reducer/src/index.ts
+++ b/reducer/src/index.ts
@@ -12,6 +12,11 @@ export type WorldEvent =
   | { id: string; source: "chain"; type: "CompanyJoined"; blockNumber: number; logIndex: number; payload: { companyId: number; member: string } }
   | { id: string; source: "chain"; type: "CompanyLeft"; blockNumber: number; logIndex: number; payload: { companyId: number; member: string } }
   | { id: string; source: "chain"; type: "MayorAssigned"; blockNumber: number; logIndex: number; payload: { mayor: string; startAt: number; endAt: number } }
+  | { id: string; source: "chain"; type: "CourseProposed"; blockNumber: number; logIndex: number; payload: { courseId: number; proposer: string; title: string; contentHash: string; difficulty: number } }
+  | { id: string; source: "chain"; type: "CourseActivated"; blockNumber: number; logIndex: number; payload: { courseId: number } }
+  | { id: string; source: "chain"; type: "CourseDeprecated"; blockNumber: number; logIndex: number; payload: { courseId: number } }
+  | { id: string; source: "chain"; type: "CourseCompleted"; blockNumber: number; logIndex: number; payload: { courseId: number; citizen: string } }
+  | { id: string; source: "chain"; type: "CredentialIssued"; blockNumber: number; logIndex: number; payload: { credentialId: number; citizen: string; courseId: number; evidenceHash: string } }
   | { id: string; source: "github"; type: "IssueLinked"; blockNumber?: number; logIndex?: number; payload: { proposalId: number; issueNumber: number; issueUrl: string } }
   | { id: string; source: "github"; type: "PullRequestMerged"; blockNumber?: number; logIndex?: number; payload: { proposalId: number; prNumber: number; mergeCommit: string; url: string } };
 
@@ -33,6 +38,10 @@ export interface WorldState {
   }>;
   companies: Record<string, { companyId: number; owner: string; name: string; metadataURI: string; members: string[] }>;
   mayor?: { wallet: string; startAt: number; endAt: number };
+  academy: {
+    courses: Record<string, { courseId: number; proposer: string; title: string; contentHash: string; difficulty: number; status: string; completionCount: number }>;
+    credentials: Record<string, { credentialId: number; citizen: string; courseId: number; evidenceHash: string; issuedAt: number }>;
+  };
   archive: WorldEvent[];
 }
 
@@ -48,6 +57,7 @@ export interface WorldManifest {
   completedProposals: Array<WorldState["proposals"][string]>;
   citizenIndexRoot: string;
   socialGraphRoot: string;
+  academyRoot: string;
   githubSync: {
     repo: string;
     commit: string;
@@ -55,7 +65,7 @@ export interface WorldManifest {
 }
 
 export function reduceEvents(events: WorldEvent[]): WorldState {
-  const state: WorldState = { citizens: {}, proposals: {}, companies: {}, archive: [] };
+  const state: WorldState = { citizens: {}, proposals: {}, companies: {}, academy: { courses: {}, credentials: {} }, archive: [] };
   for (const event of sortEvents(events)) {
     state.archive.push(event);
     switch (event.type) {
@@ -133,6 +143,41 @@ export function reduceEvents(events: WorldEvent[]): WorldState {
       case "MayorAssigned":
         state.mayor = { wallet: event.payload.mayor, startAt: event.payload.startAt, endAt: event.payload.endAt };
         break;
+      case "CourseProposed":
+        state.academy.courses[String(event.payload.courseId)] = {
+          courseId: event.payload.courseId,
+          proposer: event.payload.proposer,
+          title: event.payload.title,
+          contentHash: event.payload.contentHash,
+          difficulty: event.payload.difficulty,
+          status: "Draft",
+          completionCount: 0
+        };
+        break;
+      case "CourseActivated": {
+        const course = state.academy.courses[String(event.payload.courseId)];
+        if (course) course.status = "Active";
+        break;
+      }
+      case "CourseDeprecated": {
+        const deprecated = state.academy.courses[String(event.payload.courseId)];
+        if (deprecated) deprecated.status = "Deprecated";
+        break;
+      }
+      case "CourseCompleted": {
+        const completed = state.academy.courses[String(event.payload.courseId)];
+        if (completed) completed.completionCount++;
+        break;
+      }
+      case "CredentialIssued":
+        state.academy.credentials[String(event.payload.credentialId)] = {
+          credentialId: event.payload.credentialId,
+          citizen: event.payload.citizen,
+          courseId: event.payload.courseId,
+          evidenceHash: event.payload.evidenceHash,
+          issuedAt: event.blockNumber
+        };
+        break;
       case "IssueLinked": {
         const proposal = state.proposals[String(event.payload.proposalId)];
         if (proposal) {
@@ -165,17 +210,22 @@ export function buildManifest(input: {
   const completedProposals = proposals.filter((proposal) => ["Passed", "Rejected", "Executed"].includes(proposal.status));
   const citizenIndexRoot = hashCanonical(Object.values(input.state.citizens).sort((a, b) => a.citizenId - b.citizenId));
   const socialGraphRoot = hashCanonical(companies.map((company) => ({ companyId: company.companyId, members: [...company.members].sort() })));
+  const academyRoot = hashCanonical({
+    courses: Object.values(input.state.academy.courses).sort((a, b) => a.courseId - b.courseId),
+    credentials: Object.values(input.state.academy.credentials).sort((a, b) => a.credentialId - b.credentialId)
+  });
   const manifestWithoutRoot = {
     version: input.version,
     constitutionHash: input.constitutionHash,
     generatedAt: input.generatedAt,
-    rooms: ["plaza", "city-hall", "dev-center", "company-district", "archive"],
+    rooms: ["plaza", "city-hall", "dev-center", "company-district", "academy", "archive"],
     offices: input.state.mayor ? [{ mayor: input.state.mayor.wallet, startAt: input.state.mayor.startAt, endAt: input.state.mayor.endAt }] : [],
     companies,
     activeProposals,
     completedProposals,
     citizenIndexRoot,
     socialGraphRoot,
+    academyRoot,
     githubSync: { repo: input.githubRepo, commit: input.githubCommit }
   };
   const stateRoot = hashCanonical({ state: input.state, manifest: manifestWithoutRoot });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -70,6 +70,27 @@ export const worldStateRegistryAbi = [
   "function getWorldVersion(uint256 version) view returns ((uint256 version,string stateHash,string manifestURI,address publisher,uint256 createdAt))"
 ];
 
+export const courseRegistryAbi = [
+  "function proposeCourse(string title,string contentHash,uint8 difficulty) returns (uint256)",
+  "function activateCourse(uint256 courseId)",
+  "function deprecateCourse(uint256 courseId)",
+  "function recordCompletion(uint256 courseId)",
+  "function getCourse(uint256 courseId) view returns ((uint256 id,address proposer,string title,string contentHash,uint8 difficulty,uint8 status,uint256 createdAt,uint256 activatedAt,uint256 completionCount))",
+  "function getCourseStatus(uint256 courseId) view returns (uint8)",
+  "function getCourseCount() view returns (uint256)",
+  "function setGovernor(address newGovernor)"
+];
+
+export const credentialRegistryAbi = [
+  "function issueCredential(address citizen,uint256 courseId,string evidenceHash) returns (uint256)",
+  "function getCredential(uint256 credentialId) view returns ((uint256 id,address citizen,uint256 courseId,string evidenceHash,uint256 issuedAt,address issuedBy))",
+  "function getCredentialsByCitizen(address citizen) view returns (uint256[])",
+  "function getCredentialsByCourse(uint256 courseId) view returns (uint256[])",
+  "function getCredentialCount() view returns (uint256)",
+  "function hasCredentialForCourse(address,uint256) view returns (bool)",
+  "function setGovernor(address newGovernor)"
+];
+
 export const electionManagerAbi = [
   "function openRound() returns (uint256)",
   "function nominate(uint256 roundId,string statementURI)",


### PR DESCRIPTION
## Academy District Phase 1

Implements ACADEMY-001 and ACADEMY-002 from the P-0003 proposal.

### CourseRegistry.sol
- `proposeCourse(title, contentHash, difficulty)` - any citizen can propose
- `activateCourse(courseId)` - governor-only, activates after governance approval
- `deprecateCourse(courseId)` - governor-only
- `recordCompletion(courseId)` - citizen self-reports completion
- `getCourseStatus(courseId)` - cross-contract view for CredentialRegistry

### CredentialRegistry.sol
- `issueCredential(citizen, courseId, evidenceHash)` - governor-only, soul-bound
- One credential per course per citizen (prevents duplicates)
- Lookups by citizen and by course

### Also includes
- Reducer: 5 new WorldEvent types + `academy` state + `academyRoot` in manifest
- Chain sync: CourseRegistry/CredentialRegistry event mappers
- SDK: `courseRegistryAbi` + `credentialRegistryAbi`
- Store: seed course events
- Tests: 7 passing (was 5), +2 Academy contract tests

### Linked
- Proposal: P-0003
- Issues: ACADEMY-001, ACADEMY-002