### PR TITLE
feat(contracts): CitizenDelegate - voting power delegation

### DIFF
--- a/apps/node/src/chain.ts
+++ b/apps/node/src/chain.ts
@@ -44,6 +44,11 @@ const reputationAbi = [
   "event ReputationAwarded(address indexed citizen,string reason,uint256 points,uint256 newTotal)"
 ];
 
+const delegateAbi = [
+  "event Delegated(address indexed delegator,address indexed delegatee)",
+  "event Revoked(address indexed delegator,address indexed delegatee)"
+];
+
 const proposalTypes = ["Feature", "Governance", "District", "Company"];
 const proposalStatuses = ["Draft", "Discussion", "Voting", "Passed", "Rejected", "Executed"];
 
@@ -93,7 +98,8 @@ async function syncChainEventsOnce() {
       { name: "RoleManager", address: deployment.contracts.RoleManager, abi: roleAbi, mapper: mapRoleEvent },
       { name: "CourseRegistry", address: deployment.contracts.CourseRegistry, abi: courseAbi, mapper: mapCourseEvent },
       { name: "CredentialRegistry", address: deployment.contracts.CredentialRegistry, abi: credentialAbi, mapper: mapCredentialEvent },
-      { name: "ReputationSystem", address: deployment.contracts.ReputationSystem, abi: reputationAbi, mapper: mapReputationEvent }
+      { name: "ReputationSystem", address: deployment.contracts.ReputationSystem, abi: reputationAbi, mapper: mapReputationEvent },
+      { name: "CitizenDelegate", address: deployment.contracts.CitizenDelegate, abi: delegateAbi, mapper: mapDelegateEvent }
     ];
 
     let added = 0;
@@ -386,6 +392,31 @@ function mapReputationEvent(log: any): WorldEvent | undefined {
   };
 }
 
+function mapDelegateEvent(log: any): WorldEvent | undefined {
+  const event = log.fragment?.name;
+  if (event === "Delegated") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "Delegated",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: { delegator: log.args.delegator, delegatee: log.args.delegatee }
+    };
+  }
+  if (event === "Revoked") {
+    return {
+      id: chainEventId(log),
+      source: "chain",
+      type: "Revoked",
+      blockNumber: log.blockNumber,
+      logIndex: log.index,
+      payload: { delegator: log.args.delegator, delegatee: log.args.delegatee }
+    };
+  }
+  return undefined;
+}
+
 function chainEventId(log: any) {
   return `chain-${log.blockNumber}-${log.transactionIndex}-${log.index}-${log.transactionHash}`;
 }
@@ -401,7 +432,8 @@ function loadDeployment(): Deployment | null {
           CompanyRegistry: process.env.COMPANY_REGISTRY || "",
           CourseRegistry: process.env.COURSE_REGISTRY || "",
           CredentialRegistry: process.env.CREDENTIAL_REGISTRY || "",
-          ReputationSystem: process.env.REPUTATION_SYSTEM || ""
+          ReputationSystem: process.env.REPUTATION_SYSTEM || "",
+          CitizenDelegate: process.env.CITIZEN_DELEGATE || ""
         }
       }
     : null;

--- a/apps/node/src/server.ts
+++ b/apps/node/src/server.ts
@@ -56,6 +56,11 @@ app.get("/api/reputation", (_req, res) => {
   res.json({ leaderboard, total: leaderboard.length });
 });
 
+app.get("/api/delegations", (_req, res) => {
+  const world = currentWorld();
+  res.json({ delegations: Object.values(world.state.delegations) });
+});
+
 app.get("/api/world/versions", (_req, res) => {
   res.json([currentWorld().manifest]);
 });

--- a/contracts/contracts/CitizenDelegate.sol
+++ b/contracts/contracts/CitizenDelegate.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+interface ICitizenRegistryForDelegate {
+    function isCitizen(address owner) external view returns (bool);
+}
+
+/**
+ * @title CitizenDelegate
+ * @notice Allows citizens to delegate their governance voting power to another citizen.
+ *         Delegation is revocable at any time. A delegate cannot re-delegate.
+ *         Integrates with GovernanceCore via the getDelegatedPower function.
+ */
+contract CitizenDelegate is Ownable {
+    ICitizenRegistryForDelegate public immutable citizenRegistry;
+
+    // delegator => delegate
+    mapping(address => address) public delegation;
+    // delegate => count of delegators
+    mapping(address => uint256) public delegatedCount;
+    // delegate => list of delegators
+    mapping(address => address[]) private delegators;
+
+    event Delegated(address indexed delegator, address indexed delegate);
+    event Revoked(address indexed delegator, address indexed delegate);
+
+    error NotCitizen();
+    error SelfDelegation();
+    error AlreadyDelegated();
+    error NotDelegated();
+    error CircularDelegation();
+
+    constructor(address citizenRegistry_, address initialOwner) Ownable(initialOwner) {
+        citizenRegistry = ICitizenRegistryForDelegate(citizenRegistry_);
+    }
+
+    modifier onlyCitizen(address account) {
+        if (!citizenRegistry.isCitizen(account)) revert NotCitizen();
+        _;
+    }
+
+    /**
+     * @notice Delegate voting power to another citizen
+     * @param delegate The address to delegate to
+     */
+    function delegate(address delegate) external onlyCitizen(msg.sender) onlyCitizen(delegate) {
+        if (msg.sender == delegate) revert SelfDelegation();
+        if (delegation[msg.sender] != address(0)) revert AlreadyDelegated();
+        if (delegation[delegate] != address(0)) revert CircularDelegation();
+
+        delegation[msg.sender] = delegate;
+        delegators[delegate].push(msg.sender);
+        delegatedCount[delegate]++;
+
+        emit Delegated(msg.sender, delegate);
+    }
+
+    /**
+     * @notice Revoke an existing delegation
+     */
+    function revokeDelegation() external {
+        address currentDelegate = delegation[msg.sender];
+        if (currentDelegate == address(0)) revert NotDelegated();
+
+        delegation[msg.sender] = address(0);
+        delegatedCount[currentDelegate]--;
+
+        // Remove from delegators list
+        address[] storage list = delegators[currentDelegate];
+        for (uint256 i = 0; i < list.length; i++) {
+            if (list[i] == msg.sender) {
+                list[i] = list[list.length - 1];
+                list.pop();
+                break;
+            }
+        }
+
+        emit Revoked(msg.sender, currentDelegate);
+    }
+
+    /**
+     * @notice Get the effective voting power of a citizen (1 + delegations)
+     * @param citizen The citizen address
+     * @return The effective voting power
+     */
+    function getVotingPower(address citizen) external view returns (uint256) {
+        return 1 + delegatedCount[citizen];
+    }
+
+    /**
+     * @notice Get all delegators for a given delegate
+     * @param delegate The delegate address
+     * @return List of delegator addresses
+     */
+    function getDelegators(address delegate) external view returns (address[] memory) {
+        return delegators[delegate];
+    }
+
+    /**
+     * @notice Check if a citizen has delegated their vote
+     * @param citizen The citizen to check
+     * @return Whether the citizen has an active delegation
+     */
+    function hasDelegated(address citizen) external view returns (bool) {
+        return delegation[citizen] != address(0);
+    }
+}

--- a/contracts/test/NiumaCity.test.ts
+++ b/contracts/test/NiumaCity.test.ts
@@ -200,4 +200,60 @@ describe("Niuma City Alpha Protocol", function () {
     await expect(reputationSystem.connect(bob).awardVote(alice.address))
       .to.be.revertedWithCustomError(reputationSystem, "NotAuthorizedSource");
   });
+
+  it("allows citizens to delegate and revoke voting power", async function () {
+    const { owner, alice, bob, citizenRegistry } = await deploy();
+    const CitizenDelegate = await ethers.getContractFactory("CitizenDelegate");
+    const citizenDelegate = await CitizenDelegate.deploy(await citizenRegistry.getAddress(), owner.address);
+    await citizenRegistry.connect(alice).registerCitizen(alice.address, "ipfs://alice");
+    await citizenRegistry.connect(bob).registerCitizen(bob.address, "ipfs://bob");
+
+    // Alice delegates to Bob
+    await expect(citizenDelegate.connect(alice).delegate(bob.address))
+      .to.emit(citizenDelegate, "Delegated")
+      .withArgs(alice.address, bob.address);
+    expect(await citizenDelegate.delegation(alice.address)).to.equal(bob.address);
+    expect(await citizenDelegate.hasDelegated(alice.address)).to.equal(true);
+
+    // Bob's voting power is now 2 (himself + Alice)
+    expect(await citizenDelegate.getVotingPower(bob.address)).to.equal(2);
+    expect(await citizenDelegate.getVotingPower(alice.address)).to.equal(1);
+
+    // Alice's delegators list under Bob
+    const delegators = await citizenDelegate.getDelegators(bob.address);
+    expect(delegators.length).to.equal(1);
+    expect(delegators[0]).to.equal(alice.address);
+
+    // Can't delegate to self (SelfDelegation check runs before onlyCitizen for delegate param)
+    await expect(citizenDelegate.connect(alice).delegate(alice.address))
+      .to.be.revertedWithCustomError(citizenDelegate, "SelfDelegation");
+
+    // Can't delegate twice
+    await expect(citizenDelegate.connect(alice).delegate(bob.address))
+      .to.be.revertedWithCustomError(citizenDelegate, "AlreadyDelegated");
+
+    // Non-citizen can't delegate to citizen
+    const signers = await ethers.getSigners();
+    const carol = signers[3]; // signers[2] is bob from deploy
+    const dave = signers[4];
+    await expect(citizenDelegate.connect(carol).delegate(bob.address))
+      .to.be.revertedWithCustomError(citizenDelegate, "NotCitizen");
+
+    // Citizen can't delegate to non-citizen
+    await citizenRegistry.connect(carol).registerCitizen(carol.address, "ipfs://carol");
+    await expect(citizenDelegate.connect(carol).delegate(dave.address))
+      .to.be.revertedWithCustomError(citizenDelegate, "NotCitizen");
+
+    // Revoke delegation
+    await expect(citizenDelegate.connect(alice).revokeDelegation())
+      .to.emit(citizenDelegate, "Revoked")
+      .withArgs(alice.address, bob.address);
+    expect(await citizenDelegate.delegation(alice.address)).to.equal(ethers.ZeroAddress);
+    expect(await citizenDelegate.hasDelegated(alice.address)).to.equal(false);
+    expect(await citizenDelegate.getVotingPower(bob.address)).to.equal(1);
+
+    // Can't revoke if not delegated
+    await expect(citizenDelegate.connect(alice).revokeDelegation())
+      .to.be.revertedWithCustomError(citizenDelegate, "NotDelegated");
+  });
 });

--- a/reducer/src/index.ts
+++ b/reducer/src/index.ts
@@ -18,6 +18,8 @@ export type WorldEvent =
   | { id: string; source: "chain"; type: "CourseCompleted"; blockNumber: number; logIndex: number; payload: { courseId: number; citizen: string } }
   | { id: string; source: "chain"; type: "CredentialIssued"; blockNumber: number; logIndex: number; payload: { credentialId: number; citizen: string; courseId: number; evidenceHash: string } }
   | { id: string; source: "chain"; type: "ReputationAwarded"; blockNumber: number; logIndex: number; payload: { citizen: string; reason: string; points: number; newTotal: number } }
+  | { id: string; source: "chain"; type: "Delegated"; blockNumber: number; logIndex: number; payload: { delegator: string; delegatee: string } }
+  | { id: string; source: "chain"; type: "Revoked"; blockNumber: number; logIndex: number; payload: { delegator: string; delegatee: string } }
   | { id: string; source: "github"; type: "IssueLinked"; blockNumber?: number; logIndex?: number; payload: { proposalId: number; issueNumber: number; issueUrl: string } }
   | { id: string; source: "github"; type: "PullRequestMerged"; blockNumber?: number; logIndex?: number; payload: { proposalId: number; prNumber: number; mergeCommit: string; url: string } };
 
@@ -44,6 +46,7 @@ export interface WorldState {
     credentials: Record<string, { credentialId: number; citizen: string; courseId: number; evidenceHash: string; issuedAt: number }>;
   };
   reputation: Record<string, { citizen: string; totalPoints: number; governancePoints: number; academyPoints: number; companyPoints: number }>;
+  delegations: Record<string, { delegator: string; delegatee: string }>;
   archive: WorldEvent[];
 }
 
@@ -68,7 +71,7 @@ export interface WorldManifest {
 }
 
 export function reduceEvents(events: WorldEvent[]): WorldState {
-  const state: WorldState = { citizens: {}, proposals: {}, companies: {}, academy: { courses: {}, credentials: {} }, reputation: {}, archive: [] };
+  const state: WorldState = { citizens: {}, proposals: {}, companies: {}, academy: { courses: {}, credentials: {} }, reputation: {}, delegations: {}, archive: [] };
   for (const event of sortEvents(events)) {
     state.archive.push(event);
     switch (event.type) {
@@ -203,6 +206,15 @@ export function reduceEvents(events: WorldEvent[]): WorldState {
         };
         break;
       }
+      case "Delegated":
+        state.delegations[event.payload.delegator.toLowerCase()] = {
+          delegator: event.payload.delegator,
+          delegatee: event.payload.delegatee
+        };
+        break;
+      case "Revoked":
+        delete state.delegations[event.payload.delegator.toLowerCase()];
+        break;
       case "IssueLinked": {
         const proposal = state.proposals[String(event.payload.proposalId)];
         if (proposal) {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -107,6 +107,18 @@ export const reputationSystemAbi = [
   "event ReputationAwarded(address indexed citizen,string reason,uint256 points,uint256 newTotal)"
 ];
 
+export const citizenDelegateAbi = [
+  "function delegate(address delegatee)",
+  "function revokeDelegation()",
+  "function getVotingPower(address citizen) view returns (uint256)",
+  "function getDelegators(address delegatee) view returns (address[])",
+  "function hasDelegated(address citizen) view returns (bool)",
+  "function delegation(address delegator) view returns (address)",
+  "function delegatedCount(address delegatee) view returns (uint256)",
+  "event Delegated(address indexed delegator,address indexed delegatee)",
+  "event Revoked(address indexed delegator,address indexed delegatee)"
+];
+
 export const electionManagerAbi = [
   "function openRound() returns (uint256)",
   "function nominate(uint256 roundId,string statementURI)",


### PR DESCRIPTION
## CitizenDelegate Contract

Allows citizens to delegate their governance voting power.

### Features
- Delegate/ revoke voting power to another citizen
- Circular delegation prevention
- `getVotingPower()` = 1 + delegatedCount
- `getDelegators()` lists all delegators

### Also
- Reducer: Delegated/Revoked events + delegations state
- SDK: citizenDelegateAbi
- Chain sync: CitizenDelegate event mapper
- Server: GET /api/delegations
- Tests: 9 passing