### PR TITLE
feat: Add proposal timeline and execution checklist (Q-0012)

### DIFF
--- a/apps/node/src/server.ts
+++ b/apps/node/src/server.ts
@@ -74,6 +74,52 @@ app.get("/api/proposals/:id", (req, res) => {
   res.json(currentWorld().state.proposals[req.params.id] || null);
 });
 
+app.get("/api/proposals/:id/timeline", (req, res) => {
+  const proposalId = String(req.params.id);
+  const world = currentWorld();
+  const proposal = world.state.proposals[proposalId];
+  if (!proposal) { res.status(404).json({ error: "proposal not found" }); return; }
+
+  const timelineEntries = world.state.archive
+    .filter((event) => {
+      if (event.type === "ProposalCreated" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ProposalDiscussionStarted" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ProposalVotingStarted" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "VoteCast" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ProposalFinalized" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ProposalExecuted" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "IssueLinked" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "PullRequestMerged" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ExecutionQueued" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ExecutionCompleted" && String(event.payload.proposalId) === proposalId) return true;
+      if (event.type === "ExecutionCanceled" && String(event.payload.proposalId) === proposalId) return true;
+      return false;
+    })
+    .sort((a, b) => (a.blockNumber ?? 0) - (b.blockNumber ?? 0));
+
+  const timeline = timelineEntries.map((event) => ({
+    id: event.id,
+    type: event.type,
+    source: event.source,
+    blockNumber: event.blockNumber ?? null,
+    timestamp: event.blockNumber ?? null,
+    payload: event.payload,
+    phase: proposalPhase(event.type)
+  }));
+
+  res.json({ proposalId: Number(proposalId), proposal, timeline });
+});
+
+app.get("/api/proposals/:id/checklist", (req, res) => {
+  const proposalId = String(req.params.id);
+  const world = currentWorld();
+  const proposal = world.state.proposals[proposalId];
+  if (!proposal) { res.status(404).json({ error: "proposal not found" }); return; }
+
+  const checklist = buildExecutionChecklist(proposal, world.state.archive);
+  res.json({ proposalId: Number(proposalId), status: proposal.status, checklist });
+});
+
 app.get("/api/companies", (_req, res) => {
   res.json(Object.values(currentWorld().state.companies));
 });
@@ -633,6 +679,67 @@ async function githubHealth(repository: ReturnType<typeof repositoryLink>) {
     openPullRequests: pulls.length,
     stalePullRequests
   };
+}
+
+function proposalPhase(eventType: string): string {
+  const phaseMap: Record<string, string> = {
+    ProposalCreated: "creation",
+    ProposalDiscussionStarted: "discussion",
+    ProposalVotingStarted: "voting",
+    VoteCast: "voting",
+    ProposalFinalized: "finalization",
+    ProposalExecuted: "execution",
+    IssueLinked: "implementation",
+    PullRequestMerged: "implementation",
+    ExecutionQueued: "execution",
+    ExecutionCompleted: "execution",
+    ExecutionCanceled: "execution"
+  };
+  return phaseMap[eventType] || "unknown";
+}
+
+type ChecklistItem = {
+  id: string;
+  label: string;
+  completed: boolean;
+  detail?: string;
+  link?: string;
+};
+
+function buildExecutionChecklist(
+  proposal: { proposalId: number; status: string; issueNumber?: number; issueUrl?: string; linkedPRs: Array<{ prNumber: number; mergeCommit: string; url: string }>; executionQueue: Array<{ executionId: number; target: string; value: string; data: string; metadataURI: string; earliestExecuteAt: number; status: string; result?: string }> },
+  archive: WorldEvent[]
+): ChecklistItem[] {
+  const pid = String(proposal.proposalId);
+  const items: ChecklistItem[] = [];
+
+  const hasDiscussion = archive.some((e) => e.type === "ProposalDiscussionStarted" && String(e.payload.proposalId) === pid);
+  const hasVoting = archive.some((e) => e.type === "ProposalVotingStarted" && String(e.payload.proposalId) === pid);
+  const hasFinalized = archive.some((e) => e.type === "ProposalFinalized" && String(e.payload.proposalId) === pid);
+  const hasExecuted = archive.some((e) => e.type === "ProposalExecuted" && String(e.payload.proposalId) === pid);
+  const voteCount = archive.filter((e) => e.type === "VoteCast" && String(e.payload.proposalId) === pid).length;
+
+  items.push({ id: "create", label: "Proposal created on-chain", completed: true, detail: `by ${proposal.issueNumber ? "proposer" : "unknown"}` });
+  items.push({ id: "discuss", label: "Discussion phase started", completed: hasDiscussion });
+  items.push({ id: "vote-start", label: "Voting started", completed: hasVoting });
+  items.push({ id: "vote-count", label: `Votes cast (${voteCount} votes recorded)`, completed: voteCount > 0 });
+  items.push({ id: "finalize", label: "Proposal finalized", completed: hasFinalized, detail: proposal.status === "Rejected" ? "Rejected by voters" : undefined });
+  items.push({ id: "issue", label: "GitHub issue linked", completed: !!proposal.issueNumber, link: proposal.issueUrl });
+  items.push({ id: "pr", label: `Pull requests merged (${proposal.linkedPRs.length})`, completed: proposal.linkedPRs.length > 0, link: proposal.linkedPRs[0]?.url });
+
+  for (const execution of proposal.executionQueue) {
+    items.push({
+      id: `exec-${execution.executionId}`,
+      label: `Execution EX-${String(execution.executionId).padStart(4, "0")}`,
+      completed: execution.status === "Completed",
+      detail: execution.status === "Queued" ? `Queued, executable after ${new Date(execution.earliestExecuteAt * 1000).toISOString()}` : execution.status,
+      link: execution.metadataURI
+    });
+  }
+
+  items.push({ id: "executed", label: "Marked executed on-chain", completed: hasExecuted });
+
+  return items;
 }
 
 function loadEnvironment() {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,8 +4,11 @@ import { BrowserProvider, Contract, Eip1193Provider } from "ethers";
 import {
   Building2,
   CheckCircle2,
+  CheckSquare,
+  ChevronDown,
   ChevronRight,
   ClipboardList,
+  Clock,
   FileArchive,
   GitPullRequest,
   GraduationCap,
@@ -93,6 +96,22 @@ type CitizenProfile = {
   votes: Array<{ proposalId: number; citizenId: number; support: boolean; blockNumber: number }>;
   proofLinks: { githubIssues: string[]; githubPullRequests: string[]; credentials: string[] };
 };
+type ProposalTimelineEntry = {
+  id: string;
+  type: string;
+  source: string;
+  blockNumber: number | null;
+  timestamp: number | null;
+  payload: Record<string, unknown>;
+  phase: string;
+};
+type ProposalChecklistItem = {
+  id: string;
+  label: string;
+  completed: boolean;
+  detail?: string;
+  link?: string;
+};
 
 const apiBase = import.meta.env.VITE_API_BASE || "http://localhost:8787";
 
@@ -121,6 +140,9 @@ function App() {
   const [academyCredentials, setAcademyCredentials] = useState<Array<{credentialId:number;citizen:string;courseId:number;evidenceHash:string;issuedAt:number}>>([]);
   const [presence, setPresence] = useState<OnlinePresence>({ count: 0, ttlSeconds: 120, citizens: [] });
   const [citizenProfile, setCitizenProfile] = useState<CitizenProfile | null>(null);
+  const [selectedProposalId, setSelectedProposalId] = useState<number | null>(null);
+  const [proposalTimeline, setProposalTimeline] = useState<ProposalTimelineEntry[]>([]);
+  const [proposalChecklist, setProposalChecklist] = useState<ProposalChecklistItem[]>([]);
   const [notice, setNotice] = useState("Live node synced from X Layer Testnet events.");
   const contractsReady = Object.values(addresses).some(Boolean);
 
@@ -175,6 +197,16 @@ function App() {
   async function fetchCitizenProfile(account: string) {
     const profile = await fetch(`${apiBase}/api/citizens/${account}/profile`).then((r) => (r.ok ? r.json() : null)).catch(() => null);
     setCitizenProfile(profile);
+  }
+
+  async function fetchProposalDetail(proposalId: number) {
+    setSelectedProposalId(proposalId);
+    const [timelineRes, checklistRes] = await Promise.all([
+      fetch(`${apiBase}/api/proposals/${proposalId}/timeline`).then((r) => (r.ok ? r.json() : { timeline: [] })).catch(() => ({ timeline: [] })),
+      fetch(`${apiBase}/api/proposals/${proposalId}/checklist`).then((r) => (r.ok ? r.json() : { checklist: [] })).catch(() => ({ checklist: [] }))
+    ]);
+    setProposalTimeline(timelineRes.timeline || []);
+    setProposalChecklist(checklistRes.checklist || []);
   }
 
   async function reportPresence(account = wallet, currentCitizenId = citizenId) {
@@ -433,16 +465,37 @@ function App() {
         {view === "dev-center" && (
           <section className="dev-map">
             {proposals.map((proposal) => (
-              <article className="proposal-lane" key={proposal.proposalId}>
-                <div className="lane">
+              <article className={`proposal-lane ${selectedProposalId === proposal.proposalId ? "expanded" : ""}`} key={proposal.proposalId}>
+                <div className="lane" onClick={() => setSelectedProposalId(selectedProposalId === proposal.proposalId ? null : proposal.proposalId)}>
+                  {selectedProposalId === proposal.proposalId ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                   <span>P-{String(proposal.proposalId).padStart(4, "0")}</span>
                   <strong>{proposal.title}</strong>
+                  <span className={`proposal-badge ${proposal.status.toLowerCase()}`}>{proposal.status}</span>
                   <ChevronRight />
-                  <span>{proposal.issueNumber ? `Issue #${proposal.issueNumber}` : "No issue yet"}</span>
+                  <span>{proposal.issueNumber ? <a href={proposal.issueUrl} target="_blank" rel="noreferrer">Issue #{proposal.issueNumber}</a> : "No issue yet"}</span>
                   <ChevronRight />
                   <span>{proposal.linkedPRs.length ? `${proposal.linkedPRs.length} merged PR` : "Awaiting PR"}</span>
+                  <b>{proposal.yesVotes}y</b>
+                  <b>{proposal.noVotes}n</b>
                 </div>
-                <ExecutionQueue executions={proposal.executionQueue || []} />
+                {selectedProposalId === proposal.proposalId && (
+                  <div className="proposal-detail">
+                    <button className="timeline-load" onClick={() => fetchProposalDetail(proposal.proposalId)}>Load timeline & checklist</button>
+                    {proposalTimeline.length > 0 && (
+                      <div className="proposal-panels">
+                        <div className="panel-timeline">
+                          <h3><Clock size={16} /> Timeline ({proposalTimeline.length} events)</h3>
+                          <ProposalTimeline entries={proposalTimeline} />
+                        </div>
+                        <div className="panel-checklist">
+                          <h3><CheckSquare size={16} /> Checklist ({proposalChecklist.filter((c) => c.completed).length}/{proposalChecklist.length})</h3>
+                          <ProposalChecklist items={proposalChecklist} />
+                        </div>
+                      </div>
+                    )}
+                    <ExecutionQueue executions={proposal.executionQueue || []} />
+                  </div>
+                )}
               </article>
             ))}
           </section>
@@ -699,6 +752,100 @@ function formatUnix(value: number) {
 
 function assertAddress(address: string, name: string) {
   if (!address) throw new Error(`${name} address is not configured. Deploy contracts and set VITE_* env variables.`);
+}
+
+function ProposalTimeline({ entries }: { entries: ProposalTimelineEntry[] }) {
+  const phaseLabels: Record<string, string> = {
+    creation: "Creation",
+    discussion: "Discussion",
+    voting: "Voting",
+    finalization: "Finalization",
+    execution: "Execution",
+    implementation: "Implementation"
+  };
+  const typeIcons: Record<string, string> = {
+    ProposalCreated: "📝",
+    ProposalDiscussionStarted: "💬",
+    ProposalVotingStarted: "🗳",
+    VoteCast: "✅",
+    ProposalFinalized: "⚖",
+    ProposalExecuted: "🔧",
+    IssueLinked: "🔗",
+    PullRequestMerged: "🔀",
+    ExecutionQueued: "⏳",
+    ExecutionCompleted: "✅",
+    ExecutionCanceled: "❌"
+  };
+  return (
+    <div className="timeline-list">
+      {entries.map((entry, idx) => (
+        <div className={`timeline-entry phase-${entry.phase}`} key={entry.id}>
+          <div className="timeline-connector">
+            {idx < entries.length - 1 && <span className="timeline-line" />}
+          </div>
+          <div className="timeline-dot">{typeIcons[entry.type] || "•"}</div>
+          <div className="timeline-content">
+            <div className="timeline-header">
+              <strong>{entry.type.replace(/([A-Z])/g, " $1").trim()}</strong>
+              <span className="timeline-phase">{phaseLabels[entry.phase] || entry.phase}</span>
+              {entry.blockNumber && <small className="timeline-block">Block #{entry.blockNumber}</small>}
+            </div>
+            <div className="timeline-detail">{formatTimelineDetail(entry)}</div>
+          </div>
+        </div>
+      ))}
+      {entries.length === 0 && <p className="empty">No events recorded for this proposal.</p>}
+    </div>
+  );
+}
+
+function formatTimelineDetail(entry: ProposalTimelineEntry): React.ReactNode {
+  const p = entry.payload as Record<string, string | number | boolean>;
+  switch (entry.type) {
+    case "ProposalCreated":
+      return <span>by {short(String(p.proposer || ""))} · type: {String(p.pType || "General")}</span>;
+    case "VoteCast":
+      return <span>Citizen #{p.citizenId} ({short(String(p.voter || ""))}) voted {p.support ? "YES" : "NO"}</span>;
+    case "ProposalFinalized":
+      return <span>Status: {String(p.status)} · {p.yesVotes} yes / {p.noVotes} no</span>;
+    case "ProposalExecuted":
+      return <span>Execution hash: {short(String(p.executionHash || ""))}</span>;
+    case "IssueLinked":
+      return <a href={String(p.issueUrl || "#")} target="_blank" rel="noreferrer">Issue #{p.issueNumber}</a>;
+    case "PullRequestMerged":
+      return <a href={String(p.url || "#")} target="_blank" rel="noreferrer">PR #{p.prNumber} → {short(String(p.mergeCommit || ""))}</a>;
+    case "ExecutionQueued":
+      return <span>EX-{String(p.executionId || "").padStart(4, "0")} → {short(String(p.target || ""))} · executable after {p.earliestExecuteAt ? formatUnix(Number(p.earliestExecuteAt)) : "N/A"}</span>;
+    case "ExecutionCompleted":
+      return <span>EX-{String(p.executionId || "").padStart(4, "0")} completed · {short(String(p.result || ""))}</span>;
+    case "ExecutionCanceled":
+      return <span>EX-{String(p.executionId || "").padStart(4, "0")} canceled</span>;
+    case "ProposalDiscussionStarted":
+    case "ProposalVotingStarted":
+      return <span>Phase opened</span>;
+    default:
+      return <span>{JSON.stringify(p)}</span>;
+  }
+}
+
+function ProposalChecklist({ items }: { items: ProposalChecklistItem[] }) {
+  const completedCount = items.filter((item) => item.completed).length;
+  const allDone = completedCount === items.length && items.length > 0;
+  return (
+    <div className={`checklist ${allDone ? "all-done" : ""}`}>
+      {items.map((item) => (
+        <div className={`checklist-item ${item.completed ? "done" : "pending"}`} key={item.id}>
+          <span className="checklist-icon">{item.completed ? "✅" : "⬜"}</span>
+          <div className="checklist-content">
+            <strong>{item.label}</strong>
+            {item.detail && <small>{item.detail}</small>}
+            {item.link && <a href={item.link} target="_blank" rel="noreferrer" className="checklist-link">View →</a>}
+          </div>
+        </div>
+      ))}
+      {items.length === 0 && <p className="empty">No checklist items yet.</p>}
+    </div>
+  );
 }
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -956,3 +956,219 @@ h2 {
     grid-column: auto;
   }
 }
+
+/* Proposal timeline & checklist (Q-0012) */
+.proposal-lane.expanded {
+  border-color: rgba(105, 146, 118, 0.5);
+  background: rgba(105, 146, 118, 0.05);
+}
+
+.proposal-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.proposal-badge.draft { background: rgba(255,255,255,0.08); color: #888; }
+.proposal-badge.discussion { background: rgba(59,130,246,0.15); color: #60a5fa; }
+.proposal-badge.voting { background: rgba(245,158,11,0.15); color: #fbbf24; }
+.proposal-badge.passed { background: rgba(34,197,94,0.15); color: #4ade80; }
+.proposal-badge.executed { background: rgba(139,92,246,0.15); color: #a78bfa; }
+.proposal-badge.rejected { background: rgba(239,68,68,0.15); color: #f87171; }
+
+.lane {
+  cursor: pointer;
+  gap: 6px !important;
+}
+.lane:hover {
+  background: rgba(255,255,255,0.02);
+}
+.lane a {
+  color: #8cc5a0;
+  text-decoration: none;
+}
+.lane a:hover {
+  text-decoration: underline;
+}
+
+.proposal-detail {
+  padding: 12px 16px 16px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+
+.timeline-load {
+  margin: 0 0 12px;
+  padding: 6px 16px;
+  background: rgba(105,146,118,0.15);
+  border: 1px solid rgba(105,146,118,0.3);
+  color: #c4dcc8;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s;
+}
+.timeline-load:hover {
+  background: rgba(105,146,118,0.25);
+}
+
+.proposal-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.panel-timeline,
+.panel-checklist {
+  background: rgba(0,0,0,0.2);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 8px;
+  padding: 12px;
+}
+.panel-timeline h3,
+.panel-checklist h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #b8c8bc;
+}
+
+.timeline-list {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.timeline-entry {
+  display: flex;
+  gap: 10px;
+  position: relative;
+  padding: 6px 0;
+}
+.timeline-connector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 20px;
+  flex-shrink: 0;
+}
+.timeline-line {
+  width: 2px;
+  flex: 1;
+  background: rgba(255,255,255,0.08);
+  margin-top: 4px;
+}
+.timeline-dot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.phase-creation .timeline-dot { background: rgba(59,130,246,0.15); border-color: rgba(59,130,246,0.3); }
+.phase-discussion .timeline-dot { background: rgba(59,130,246,0.15); border-color: rgba(59,130,246,0.3); }
+.phase-voting .timeline-dot { background: rgba(245,158,11,0.15); border-color: rgba(245,158,11,0.3); }
+.phase-finalization .timeline-dot { background: rgba(34,197,94,0.15); border-color: rgba(34,197,94,0.3); }
+.phase-execution .timeline-dot { background: rgba(139,92,246,0.15); border-color: rgba(139,92,246,0.3); }
+.phase-implementation .timeline-dot { background: rgba(105,146,118,0.15); border-color: rgba(105,146,118,0.3); }
+
+.timeline-content {
+  flex: 1;
+  min-width: 0;
+}
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.timeline-header strong {
+  font-size: 12px;
+  color: #d4e0d6;
+}
+.timeline-phase {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.06);
+  color: #888;
+  text-transform: uppercase;
+}
+.timeline-block {
+  font-size: 10px;
+  color: #666;
+}
+.timeline-detail {
+  font-size: 12px;
+  color: #999;
+  margin-top: 2px;
+}
+.timeline-detail a {
+  color: #8cc5a0;
+  text-decoration: none;
+}
+.timeline-detail a:hover {
+  text-decoration: underline;
+}
+
+.checklist-item {
+  display: flex;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.checklist-item:last-child {
+  border-bottom: none;
+}
+.checklist-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.checklist-content {
+  flex: 1;
+  min-width: 0;
+}
+.checklist-content strong {
+  font-size: 12px;
+  display: block;
+  color: #d4e0d6;
+}
+.checklist-item.done .checklist-content strong {
+  color: #6b9;
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+.checklist-content small {
+  font-size: 11px;
+  color: #777;
+  display: block;
+  margin-top: 2px;
+}
+.checklist-link {
+  font-size: 11px;
+  color: #8cc5a0;
+  text-decoration: none;
+}
+.checklist-link:hover {
+  text-decoration: underline;
+}
+.checklist.all-done {
+  border-left: 3px solid #4ade80;
+  padding-left: 10px;
+  border-radius: 4px;
+}
+
+@media (max-width: 800px) {
+  .proposal-panels {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #25 (Q-0012)

Adds proposal timeline and execution checklist features:

### Server
- `GET /api/proposals/:id/timeline` - chronological event timeline filtered by proposal
- `GET /api/proposals/:id/checklist` - execution checklist with completion tracking

### Web
- Expandable proposal lanes with full timeline view
- Proposal status badges
- Execution checklist display with completion indicators

### Acceptance Criteria
- [x] Proposal details include a chronological timeline
- [x] Passed proposals generate an execution checklist
- [x] Timeline links to GitHub issues and PRs (via event payload)